### PR TITLE
Add quick capture status after watch mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ from detector.network_detector import NetworkDetector
 from detector.writer import RotatingJsonlWriter
 from worker.llm_client import OllamaClient
 from worker.report_generator import ReportGenerator
+from quick_status import show_log_event_status
 
 # Configure logging
 logging.basicConfig(
@@ -323,6 +324,7 @@ class Clearwatch:
             if self.writer:
                 self.writer.close()
             print(f"\nWatch mode completed. Total events captured: {event_count}")
+            show_log_event_status()
             
     def _analysis_mode(self):
         """Execute Analysis Mode - analyze previous captures."""

--- a/quick_status.py
+++ b/quick_status.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Quick status helper for Clearwatch watch mode."""
+from pathlib import Path
+
+def show_log_event_status() -> None:
+    """Print presence of log and event files."""
+    logs_dir = Path("clearwatch/logs")
+    events_dir = Path("clearwatch/events")
+
+    log_file = logs_dir / "clearwatch.log"
+    event_files = list(events_dir.glob("*.jsonl")) if events_dir.exists() else []
+
+    print("\n\U0001F4CA Quick capture status:")
+    print(f"   Log file present: {'\u2705' if log_file.exists() else '\u274C'} ({log_file})")
+    print(f"   Event files present: {'\u2705' if event_files else '\u274C'} ({events_dir})")
+


### PR DESCRIPTION
## Summary
- introduce `quick_status` helper to report log and event file presence
- call the helper after watch mode completes for immediate feedback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5853b22e48325ac2740429427dd63